### PR TITLE
Remove Badges from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 # Starter Go
 
-[![build status](https://img.shields.io/github/actions/workflow/status/threeal/starter-go/test.yml?style=flat-square)](https://github.com/threeal/starter-go/actions/workflows/test.yml)
-
 A minimalistic [Go](https://go.dev/) template to kickstart your project.


### PR DESCRIPTION
This pull request resolves #367 by simply removing badges from the root `README.md` file.